### PR TITLE
fix: resolve multi-environment Helm secret ownership conflicts

### DIFF
--- a/helm/redstone/templates/secrets.yaml
+++ b/helm/redstone/templates/secrets.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "redstone.fullname" . }}-secrets
+  name: {{ include "redstone.fullname" . }}-app-secrets
   labels:
     {{- include "redstone.labels" . | nindent 4 }}
 type: Opaque


### PR DESCRIPTION
- Changed secret name from 'redstone-secrets' to 'redstone-app-secrets'
- Avoids conflicts with existing unmanaged secrets in all Release.com namespaces
- Resolves deployment failures on both main and feature branch environments
- Allows Helm to properly manage secrets with correct ownership metadata
- Enables successful deployments across all environments